### PR TITLE
docs: warn against project-scoped MCP registration (anthropics/claude-code#13898)

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,20 @@ Add to your Claude Code settings (`~/.claude/settings.json`):
 }
 ```
 
+> ⚠️ **Warning: register Oracle at user scope only**
+>
+> Register Oracle in `~/.claude/settings.json` (user scope) as shown above. **Do not register Oracle in a project-level `.mcp.json` file.**
+>
+> Due to upstream bug [anthropics/claude-code#13898](https://github.com/anthropics/claude-code/issues/13898), custom subagents cannot reach MCP servers configured at project scope. Instead of erroring, they silently hallucinate plausible-looking results — meaning **custom subagents will return fabricated Oracle results with no error indicator**. Made-up `oracle_read` deltas, made-up `oracle_status` snapshots, made-up cache hits. The subagent reports success and the agent acts on the fabricated data.
+>
+> **What works correctly:**
+> - User-scope registration in `~/.claude/settings.json` (the example above).
+> - The built-in `general-purpose` subagent — use it when subagent invocation is required. It is unaffected by this bug.
+>
+> There is no Oracle-side workaround; the bug is in Claude Code's subagent MCP plumbing.
+>
+> *Last verified: 2026-04-26.* Remove this warning when anthropics/claude-code#13898 is closed AND a Claude Code release notes entry confirms the fix.
+
 ### 2. Install the AYLO hooks
 
 Copy the hook scripts and register them in your Claude Code settings:


### PR DESCRIPTION
## Summary

Adds a callout block to the README's Configuration section warning users against registering Project Oracle in a project-level `.mcp.json`. Per [anthropics/claude-code#13898](https://github.com/anthropics/claude-code/issues/13898) (open as of 2025-12-13), custom subagents silently hallucinate fabricated MCP results when MCP servers are configured in project scope rather than user scope. Without this warning, users following a reasonable instinct (keep config in version control with the project) would hit a debugging trap with no error indicator.

The callout names:
- The symptom verbatim: \"custom subagents will return fabricated Oracle results with no error indicator\"
- The supported scope: \`~/.claude/settings.json\`
- The safe built-in subagent: \`general-purpose\`
- The upstream tracking issue
- A removal trigger: when anthropics/claude-code#13898 closes AND a Claude Code release notes entry confirms the fix

Closes #14.

## Changes

- README.md: +14 lines in the Configuration section. Existing user-scope JSON example unchanged. No project-scope JSON example added (showing the broken pattern would invite copy-paste into bug).

## Gauntlet

Adversarial review verdict: **PASS**. Verbatim string requirements met, no scope creep, markdown renders cleanly, no slop, no project-scope JSON example introduced.

## Test plan

- [x] README renders correctly on GitHub (visual check the blockquote callout)
- [x] All AC scenarios from #14 verified
- [x] No regressions to surrounding sections

🤖 Generated with [Claude Code](https://claude.ai/claude-code)