### PR TITLE
refactor: make AYLO PreToolUse hook binary instead of advisory (Read only)

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Project Oracle (MCP server)
 | Layer | Mechanism | What it does |
 |-------|-----------|-------------|
 | **Passive learning** | PostToolUse hooks | When the agent uses built-in `Read`/`Grep`/`Bash`, hooks silently feed the results to Oracle's cache |
-| **Active nudging** | PreToolUse AYLO hooks | Before the agent re-reads a file, a question nudges it toward `oracle_read` instead |
+| **Binary blocking on Read** | PreToolUse hook | When the agent re-reads a file it already saw this session and the file is unchanged on disk, the hook exits 2 and the Read does not execute. Bash/Grep stay advisory. |
 | **Direct tools** | 7 MCP tools | `oracle_status`, `oracle_ask`, `oracle_run`, `oracle_read`, `oracle_grep`, `oracle_forget`, `oracle_stats` |
 
 State persists in per-project SQLite databases, so the agent picks up where it left off across sessions.
@@ -288,7 +288,8 @@ export ANTHROPIC_API_KEY="sk-ant-..."
 ┌──────────────────────────────────────────────────┐
 │  Claude Code Hooks (run in parallel)             │
 │                                                  │
-│  PreToolUse: AYLO nudges → "use oracle instead"  │
+│  PreToolUse Read: binary block on redundant Read │
+│  PreToolUse Bash/Grep: advisory (additionalCtx)  │
 │  PostToolUse: passive ingest → feed to cache     │
 └──────────────────────────────────────────────────┘
 ```
@@ -435,7 +436,8 @@ features/
 ├── file_caching.feature      # BDD: file read/delta behavior
 ├── git_state.feature         # BDD: git status caching
 ├── command_caching.feature   # BDD: command result caching
-└── natural_language.feature  # BDD: oracle_ask routing
+├── natural_language.feature  # BDD: oracle_ask routing
+└── hooks.feature             # BDD: PreToolUse Read binary block
 ```
 
 ## License

--- a/features/hooks.feature
+++ b/features/hooks.feature
@@ -1,0 +1,108 @@
+@ISSUE-13
+Feature: PreToolUse hook blocks only provably redundant Reads in the current session
+  The hook is binary on Read: exit 2 to block when the file was both served
+  this session and is unchanged on disk; exit 0 in every other case. Bash
+  and Grep stay advisory.
+
+  Background:
+    Given Oracle's MCP server is running and tracking the current project
+    And the AYLO PreToolUse hook is registered for Read
+    And the per-project SQLite database has a session_files table populated by both the MCP server and the ingest worker
+
+  @ISSUE-13
+  Scenario: Redundant Read served via oracle_read this session is blocked
+    Given the agent called oracle_read on "src/foo.py" earlier in the current session
+    And session_files contains a row for the current session and "src/foo.py"
+    And file_cache.disk_sha256 for "src/foo.py" equals its current on-disk SHA-256
+    When the hook fires for Read on "src/foo.py" with no offset or limit
+    Then the hook exits with code 2
+    And stderr contains "File unchanged since last read"
+    And stderr contains the resolved path of "src/foo.py"
+
+  @ISSUE-13
+  Scenario: Redundant Read after PostToolUse ingest is blocked
+    Given the agent called Read on "src/foo.py" earlier in the current session
+    And the ingest worker has consumed the event and inserted into session_files
+    And file_cache.disk_sha256 for "src/foo.py" still matches on-disk
+    When the hook fires for Read on "src/foo.py" with no offset or limit
+    Then the hook exits with code 2
+
+  @ISSUE-13
+  Scenario: Cross-session unchanged file with no current-session record is allowed
+    Given file_cache contains "src/legacy.py" with a matching disk_sha256 from a prior session
+    And session_files contains no row for the current session and "src/legacy.py"
+    When the hook fires for Read on "src/legacy.py"
+    Then the hook exits with code 0
+
+  @ISSUE-13
+  Scenario: First Read of a file in the current session is allowed
+    Given session_files contains no row for the current session and "src/bar.py"
+    When the hook fires for Read on "src/bar.py"
+    Then the hook exits with code 0
+
+  @ISSUE-13
+  Scenario: Read of a changed file is allowed even if served this session
+    Given session_files contains a row for the current session and "src/baz.py"
+    And file_cache.disk_sha256 for "src/baz.py" differs from its current on-disk SHA-256
+    When the hook fires for Read on "src/baz.py"
+    Then the hook exits with code 0
+
+  @ISSUE-13
+  Scenario: Ingest race — agent re-reads before the ingest worker has processed the prior Read
+    Given the agent just called Read on "src/quick.py"
+    And the ingest worker has not yet inserted into session_files for that Read
+    When the hook fires for Read on "src/quick.py"
+    Then the hook exits with code 0
+
+  @ISSUE-13
+  Scenario: Oracle SQLite unreachable falls back to allow
+    Given the per-project SQLite database file does not exist
+    When the hook fires for Read on "src/foo.py"
+    Then the hook exits with code 0
+
+  @ISSUE-13
+  Scenario: Partial Read with non-default offset is allowed
+    Given session_files contains a row for the current session and "src/foo.py"
+    And file_cache.disk_sha256 for "src/foo.py" matches on-disk
+    When the hook fires for Read on "src/foo.py" with offset 0 and limit 100
+    Then the hook exits with code 0
+
+  @ISSUE-13
+  Scenario: Full Read after a partial Read is blocked
+    Given the agent first called Read on "src/foo.py" with offset 0 and limit 100
+    And the ingest worker added a row for the current session and "src/foo.py"
+    And file_cache.disk_sha256 for "src/foo.py" still matches on-disk
+    When the hook fires for Read on "src/foo.py" with no offset or limit
+    Then the hook exits with code 2
+
+  @ISSUE-13
+  Scenario: Path outside any tracked project is allowed
+    When the hook fires for Read on a path outside any tracked project root
+    Then the hook exits with code 0
+
+  @ISSUE-13
+  Scenario: Symlink whose resolved target is in session_files is blocked
+    Given "src/symlink.py" is a symbolic link to "src/foo.py"
+    And session_files contains a row for the current session and the resolved target "src/foo.py"
+    And file_cache.disk_sha256 for "src/foo.py" matches on-disk
+    When the hook fires for Read on "src/symlink.py"
+    Then the hook exits with code 2
+
+  @ISSUE-13
+  Scenario: Escalation counter is removed from the hook source
+    When inspecting the hook source for "get_count", "set_count", and "COUNTER_DIR"
+    Then no matches are found
+
+  @ISSUE-13
+  Scenario: Bash advisory remains intact and non-blocking
+    When the hook fires for Bash with command "ls -la"
+    Then the hook exits with code 0
+    And stdout contains "additionalContext"
+    And stdout contains "oracle_run"
+
+  @ISSUE-13
+  Scenario: Grep advisory remains intact and non-blocking
+    When the hook fires for Grep with pattern "needle"
+    Then the hook exits with code 0
+    And stdout contains "additionalContext"
+    And stdout contains "oracle_grep"

--- a/features/hooks.feature
+++ b/features/hooks.feature
@@ -124,6 +124,16 @@ Feature: PreToolUse hook blocks only provably redundant Reads in the current ses
     And stderr is empty
 
   @ISSUE-13
+  Scenario: gtimeout-only PATH still fires the binary block
+    Given Oracle's MCP server is tracking the project
+    And session_files contains (the current session, "src/foo.py")
+    And file_cache.disk_sha256 for "src/foo.py" matches its current on-disk SHA-256
+    And PATH contains gtimeout but NOT timeout
+    When the agent calls Read with file_path "src/foo.py" and no offset/limit
+    Then the hook exits with code 2
+    And stderr contains "File unchanged since last read"
+
+  @ISSUE-13
   Scenario: Hook source explicitly detects timeout/gtimeout availability
     When inspecting the hook source for the timeout fallback
     Then the hook source declares both "timeout" and "gtimeout" as candidates

--- a/features/hooks.feature
+++ b/features/hooks.feature
@@ -61,10 +61,17 @@ Feature: PreToolUse hook blocks only provably redundant Reads in the current ses
     Then the hook exits with code 0
 
   @ISSUE-13
-  Scenario: Partial Read with non-default offset is allowed
-    Given session_files contains a row for the current session and "src/foo.py"
+  Scenario: Partial Read overrides the would-block SHA-match path
+    Given the agent called Read on "src/foo.py" earlier in the current session
+    And session_files contains a row for the current session and "src/foo.py"
     And file_cache.disk_sha256 for "src/foo.py" matches on-disk
     When the hook fires for Read on "src/foo.py" with offset 0 and limit 100
+    Then the hook exits with code 0
+
+  @ISSUE-13
+  Scenario: Partial Read of an unseen file is allowed
+    Given session_files contains no row for the current session and "src/never.py"
+    When the hook fires for Read on "src/never.py" with offset 10 and limit 50
     Then the hook exits with code 0
 
   @ISSUE-13

--- a/features/hooks.feature
+++ b/features/hooks.feature
@@ -113,3 +113,18 @@ Feature: PreToolUse hook blocks only provably redundant Reads in the current ses
     Then the hook exits with code 0
     And stdout contains "additionalContext"
     And stdout contains "oracle_grep"
+
+  @ISSUE-13
+  Scenario: No timeout binary on PATH fails open silently
+    Given the agent called Read on "src/foo.py" earlier in the current session
+    And file_cache.disk_sha256 for "src/foo.py" matches on-disk
+    And neither timeout nor gtimeout is on PATH
+    When the hook fires for Read on "src/foo.py" with no offset or limit
+    Then the hook exits with code 0
+    And stderr is empty
+
+  @ISSUE-13
+  Scenario: Hook source explicitly detects timeout/gtimeout availability
+    When inspecting the hook source for the timeout fallback
+    Then the hook source declares both "timeout" and "gtimeout" as candidates
+    And the hook source uses the resolved timeout command via a variable

--- a/features/steps/hook_steps.py
+++ b/features/steps/hook_steps.py
@@ -1,0 +1,369 @@
+"""Step definitions for hooks.feature — exercise lights-on-oracle-pre.sh against
+real SQLite fixtures.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import subprocess
+import time
+from pathlib import Path
+
+from behave import given, then, when
+
+from oracle.storage.store import OracleStore
+
+HOOK_SCRIPT = (
+    Path(__file__).resolve().parent.parent.parent / "hooks" / "lights-on-oracle-pre.sh"
+)
+SESSION_ID = "behave-test-session"
+
+
+def _setup_project(context) -> Path:
+    if hasattr(context, "hook_project_root"):
+        return context.hook_project_root
+    project = context.tmp_dir / "project"
+    project.mkdir(exist_ok=True)
+    (project / ".git").mkdir(exist_ok=True)
+    (project / "src").mkdir(exist_ok=True)
+    context.hook_project_root = project
+    context.hook_oracle_dir = context.tmp_dir / "oracle"
+    (context.hook_oracle_dir / "projects").mkdir(parents=True, exist_ok=True)
+    pid = hashlib.sha256(str(project.resolve()).encode()).hexdigest()[:8]
+    context.hook_db_dir = context.hook_oracle_dir / "projects" / pid
+    context.hook_db_dir.mkdir(parents=True, exist_ok=True)
+    context.hook_db_path = context.hook_db_dir / "oracle.db"
+    context.hook_store = OracleStore(context.hook_db_path)
+    return project
+
+
+def _resolve(context, path: str) -> str:
+    return str((context.hook_project_root / path).resolve())
+
+
+def _write_file_cache(context, rel_path: str, content: bytes, disk_sha: str) -> None:
+    full = _resolve(context, rel_path)
+    context.hook_store.upsert_file_cache(
+        full, content, disk_sha, disk_sha, int(time.time())
+    )
+
+
+def _record_session(context, rel_path: str) -> None:
+    full = _resolve(context, rel_path)
+    context.hook_store.record_session_file(SESSION_ID, full, int(time.time()))
+
+
+def _run_hook(context, payload: dict, file_path_for_resolve: str | None = None) -> None:
+    env = os.environ.copy()
+    env["ORACLE_DIR"] = str(context.hook_oracle_dir)
+    if hasattr(context, "hook_store"):
+        context.hook_store.close()
+        context.hook_store = OracleStore(context.hook_db_path)
+    result = subprocess.run(
+        [str(HOOK_SCRIPT)],
+        input=json.dumps(payload),
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+    context.hook_exit_code = result.returncode
+    context.hook_stdout = result.stdout
+    context.hook_stderr = result.stderr
+    context.hook_resolved = file_path_for_resolve
+
+
+def _make_file(context, rel_path: str, content: str = "print('hello')\n") -> str:
+    project = _setup_project(context)
+    full = project / rel_path
+    full.parent.mkdir(parents=True, exist_ok=True)
+    full.write_text(content)
+    return _resolve(context, rel_path)
+
+
+@given("Oracle's MCP server is running and tracking the current project")
+def step_mcp_running(context):
+    _setup_project(context)
+
+
+@given("the AYLO PreToolUse hook is registered for Read")
+def step_hook_registered(context):
+    assert HOOK_SCRIPT.exists(), f"Hook script missing: {HOOK_SCRIPT}"
+
+
+@given(
+    "the per-project SQLite database has a session_files table "
+    "populated by both the MCP server and the ingest worker"
+)
+def step_db_has_session_files(context):
+    _setup_project(context)
+    # session_files exists via _init_schema
+    rows = context.hook_store._conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='session_files'"
+    ).fetchall()
+    assert rows, "session_files table missing"
+
+
+@given('the agent called oracle_read on "{rel_path}" earlier in the current session')
+def step_agent_oracle_read(context, rel_path):
+    full = _make_file(context, rel_path)
+    content = Path(full).read_bytes()
+    sha = hashlib.sha256(content).hexdigest()
+    _write_file_cache(context, rel_path, content, sha)
+    _record_session(context, rel_path)
+
+
+@given('the agent called Read on "{rel_path}" earlier in the current session')
+def step_agent_builtin_read(context, rel_path):
+    full = _make_file(context, rel_path)
+    content = Path(full).read_bytes()
+    sha = hashlib.sha256(content).hexdigest()
+    _write_file_cache(context, rel_path, content, sha)
+    _record_session(context, rel_path)
+
+
+@given(
+    "session_files contains a row for the current session and "
+    '"{rel_path}"'
+)
+def step_session_files_has_row(context, rel_path):
+    _make_file(context, rel_path)
+    _record_session(context, rel_path)
+
+
+@given(
+    "session_files contains a row for the current session and the resolved target "
+    '"{rel_path}"'
+)
+def step_session_files_has_resolved_target(context, rel_path):
+    full = _make_file(context, rel_path)
+    content = Path(full).read_bytes()
+    sha = hashlib.sha256(content).hexdigest()
+    _write_file_cache(context, rel_path, content, sha)
+    _record_session(context, rel_path)
+
+
+@given('"{symlink_path}" is a symbolic link to "{target}"')
+def step_symlink(context, symlink_path, target):
+    project = _setup_project(context)
+    target_full = project / target
+    if not target_full.exists():
+        target_full.parent.mkdir(parents=True, exist_ok=True)
+        target_full.write_text("print('hello')\n")
+    sym_full = project / symlink_path
+    sym_full.parent.mkdir(parents=True, exist_ok=True)
+    if sym_full.exists() or sym_full.is_symlink():
+        sym_full.unlink()
+    sym_full.symlink_to(target_full)
+
+
+@given(
+    'file_cache.disk_sha256 for "{rel_path}" equals its current on-disk SHA-256'
+)
+def step_disk_sha_matches(context, rel_path):
+    full = _resolve(context, rel_path)
+    content = Path(full).read_bytes()
+    sha = hashlib.sha256(content).hexdigest()
+    context.hook_store.upsert_file_cache(full, content, sha, sha, int(time.time()))
+
+
+@given('file_cache.disk_sha256 for "{rel_path}" matches on-disk')
+def step_disk_sha_matches_short(context, rel_path):
+    step_disk_sha_matches(context, rel_path)
+
+
+@given('file_cache.disk_sha256 for "{rel_path}" still matches on-disk')
+def step_disk_sha_still_matches(context, rel_path):
+    step_disk_sha_matches(context, rel_path)
+
+
+@given(
+    'file_cache.disk_sha256 for "{rel_path}" differs from its current on-disk SHA-256'
+)
+def step_disk_sha_differs(context, rel_path):
+    # Ensure the file exists, then store a stale SHA in file_cache
+    _make_file(context, rel_path)
+    full = _resolve(context, rel_path)
+    content = Path(full).read_bytes()
+    stale_sha = "stale" + "0" * 59  # 64-char hex placeholder distinct from real SHA
+    context.hook_store.upsert_file_cache(full, content, stale_sha, stale_sha, int(time.time()))
+
+
+@given(
+    'file_cache contains "{rel_path}" with a matching disk_sha256 from a prior session'
+)
+def step_cross_session_cache(context, rel_path):
+    full = _make_file(context, rel_path)
+    content = Path(full).read_bytes()
+    sha = hashlib.sha256(content).hexdigest()
+    _write_file_cache(context, rel_path, content, sha)
+
+
+@given('session_files contains no row for the current session and "{rel_path}"')
+def step_session_files_no_row(context, rel_path):
+    _setup_project(context)
+    # Ensure the file exists so the hook can resolve it
+    _make_file(context, rel_path)
+
+
+@given('the agent just called Read on "{rel_path}"')
+def step_agent_just_called_read(context, rel_path):
+    _make_file(context, rel_path)
+
+
+@given(
+    "the ingest worker has not yet inserted into session_files for that Read"
+)
+def step_ingest_not_yet(context):
+    pass  # No row recorded
+
+
+@given(
+    "the ingest worker has consumed the event and inserted into session_files"
+)
+def step_ingest_consumed(context):
+    # already recorded above by step_agent_builtin_read
+    pass
+
+
+@given("the per-project SQLite database file does not exist")
+def step_db_missing(context):
+    project = _setup_project(context)
+    # Close the store and remove the DB file
+    context.hook_store.close()
+    if context.hook_db_path.exists():
+        context.hook_db_path.unlink()
+    # Make a placeholder so the file path remains valid for the project,
+    # but ensure the actual DB file is missing
+    context.hook_resolved_target = project
+
+
+@given(
+    'the agent first called Read on "{rel_path}" with offset 0 and limit 100'
+)
+def step_agent_partial_read(context, rel_path):
+    _make_file(context, rel_path)
+
+
+@given(
+    "the ingest worker added a row for the current session and "
+    '"{rel_path}"'
+)
+def step_ingest_added_row(context, rel_path):
+    full = _resolve(context, rel_path)
+    content = Path(full).read_bytes()
+    sha = hashlib.sha256(content).hexdigest()
+    _write_file_cache(context, rel_path, content, sha)
+    _record_session(context, rel_path)
+
+
+@when(
+    'the hook fires for Read on "{rel_path}" with no offset or limit'
+)
+def step_when_read_no_partial(context, rel_path):
+    full = _resolve(context, rel_path)
+    payload = {
+        "session_id": SESSION_ID,
+        "tool_name": "Read",
+        "tool_input": {"file_path": full},
+    }
+    _run_hook(context, payload, file_path_for_resolve=full)
+
+
+@when('the hook fires for Read on "{rel_path}"')
+def step_when_read(context, rel_path):
+    step_when_read_no_partial(context, rel_path)
+
+
+@when(
+    'the hook fires for Read on "{rel_path}" with offset {offset:d} and limit {limit:d}'
+)
+def step_when_read_partial(context, rel_path, offset, limit):
+    full = _resolve(context, rel_path)
+    payload = {
+        "session_id": SESSION_ID,
+        "tool_name": "Read",
+        "tool_input": {"file_path": full, "offset": offset, "limit": limit},
+    }
+    _run_hook(context, payload, file_path_for_resolve=full)
+
+
+@when("the hook fires for Read on a path outside any tracked project root")
+def step_when_read_outside(context):
+    _setup_project(context)
+    payload = {
+        "session_id": SESSION_ID,
+        "tool_name": "Read",
+        "tool_input": {"file_path": "/etc/hosts"},
+    }
+    _run_hook(context, payload)
+
+
+@when('the hook fires for Bash with command "{command}"')
+def step_when_bash(context, command):
+    _setup_project(context)
+    payload = {
+        "session_id": SESSION_ID,
+        "tool_name": "Bash",
+        "tool_input": {"command": command},
+    }
+    _run_hook(context, payload)
+
+
+@when('the hook fires for Grep with pattern "{pattern}"')
+def step_when_grep(context, pattern):
+    _setup_project(context)
+    payload = {
+        "session_id": SESSION_ID,
+        "tool_name": "Grep",
+        "tool_input": {"pattern": pattern},
+    }
+    _run_hook(context, payload)
+
+
+@when(
+    'inspecting the hook source for "{a}", "{b}", and "{c}"'
+)
+def step_inspect_hook_source(context, a, b, c):
+    text = HOOK_SCRIPT.read_text()
+    context.hook_source_matches = [s for s in (a, b, c) if s in text]
+
+
+@then("the hook exits with code {code:d}")
+def step_then_exit(context, code):
+    assert context.hook_exit_code == code, (
+        f"Expected exit {code}, got {context.hook_exit_code}.\n"
+        f"stdout: {context.hook_stdout}\n"
+        f"stderr: {context.hook_stderr}"
+    )
+
+
+@then('stderr contains "{text}"')
+def step_then_stderr_contains(context, text):
+    assert text in context.hook_stderr, (
+        f"Expected '{text}' in stderr; got: {context.hook_stderr!r}"
+    )
+
+
+@then('stderr contains the resolved path of "{rel_path}"')
+def step_then_stderr_contains_resolved_path(context, rel_path):
+    full = _resolve(context, rel_path)
+    assert full in context.hook_stderr, (
+        f"Expected '{full}' in stderr; got: {context.hook_stderr!r}"
+    )
+
+
+@then('stdout contains "{text}"')
+def step_then_stdout_contains(context, text):
+    assert text in context.hook_stdout, (
+        f"Expected '{text}' in stdout; got: {context.hook_stdout!r}"
+    )
+
+
+@then("no matches are found")
+def step_then_no_matches(context):
+    assert context.hook_source_matches == [], (
+        f"Expected no matches, found: {context.hook_source_matches}"
+    )

--- a/features/steps/hook_steps.py
+++ b/features/steps/hook_steps.py
@@ -7,6 +7,8 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import shutil
+import stat
 import subprocess
 import time
 from pathlib import Path
@@ -398,3 +400,90 @@ def step_then_no_matches(context):
     assert context.hook_source_matches == [], (
         f"Expected no matches, found: {context.hook_source_matches}"
     )
+
+
+@given("Oracle's MCP server is tracking the project")
+def step_mcp_tracking(context):
+    _setup_project(context)
+
+
+@given('session_files contains (the current session, "{rel_path}")')
+def step_session_files_contains_tuple(context, rel_path):
+    full = _make_file(context, rel_path)
+    content = Path(full).read_bytes()
+    sha = hashlib.sha256(content).hexdigest()
+    _write_file_cache(context, rel_path, content, sha)
+    _record_session(context, rel_path)
+
+
+@given('file_cache.disk_sha256 for "{rel_path}" matches its current on-disk SHA-256')
+def step_disk_sha_matches_current(context, rel_path):
+    step_disk_sha_matches(context, rel_path)
+
+
+@given("PATH contains gtimeout but NOT timeout")
+def step_path_has_gtimeout_only(context):
+    # The hook needs `timeout` or `gtimeout` to enforce its SQLite query
+    # timeout. To exercise the gtimeout fallback hermetically without
+    # depending on the host's coreutils, build an isolated PATH that:
+    #   1. Symlinks the helpers the hook needs (jq, sqlite3, shasum, etc.)
+    #   2. Does NOT include `timeout`
+    #   3. DOES include a `gtimeout` shim that execs the host's actual
+    #      timeout-like binary by absolute path (so the hook's
+    #      `command -v gtimeout` succeeds and the resulting invocation
+    #      really enforces a timeout).
+    # If the host has neither `timeout` nor `gtimeout`, skip — there's no
+    # way to make a working shim and the scenario can't be exercised.
+    host_timeout = shutil.which("timeout") or shutil.which("gtimeout")
+    if host_timeout is None:
+        context.scenario.skip(
+            reason="Host has neither `timeout` nor `gtimeout`; gtimeout shim has nothing to exec."
+        )
+        return
+
+    isolated = context.tmp_dir / "gtimeout-only-bin"
+    isolated.mkdir(exist_ok=True)
+    helpers = [
+        "jq",
+        "sqlite3",
+        "shasum",
+        "awk",
+        "sed",
+        "mktemp",
+        "realpath",
+        "dirname",
+        "printf",
+        "cat",
+        "bash",
+        "head",
+        "rm",
+    ]
+    seen: set[str] = set()
+    for path_dir in os.environ.get("PATH", "").split(os.pathsep):
+        if not path_dir:
+            continue
+        for helper in helpers:
+            if helper in seen:
+                continue
+            candidate = Path(path_dir) / helper
+            if candidate.exists():
+                link = isolated / helper
+                if not link.exists():
+                    link.symlink_to(candidate)
+                seen.add(helper)
+
+    # gtimeout shim: exec the host's real timeout binary by absolute path.
+    # The hook will detect this via `command -v gtimeout` and invoke it
+    # exactly like the GNU `timeout` it stands in for.
+    gtimeout_shim = isolated / "gtimeout"
+    gtimeout_shim.write_text(f'#!/bin/bash\nexec "{host_timeout}" "$@"\n')
+    gtimeout_shim.chmod(gtimeout_shim.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+    # Crucially, do NOT symlink `timeout` itself — the hook must fall
+    # through to the gtimeout branch.
+    context.hook_path_override = str(isolated)
+
+
+@when('the agent calls Read with file_path "{rel_path}" and no offset/limit')
+def step_when_agent_calls_read(context, rel_path):
+    step_when_read_no_partial(context, rel_path)

--- a/features/steps/hook_steps.py
+++ b/features/steps/hook_steps.py
@@ -15,9 +15,7 @@ from behave import given, then, when
 
 from oracle.storage.store import OracleStore
 
-HOOK_SCRIPT = (
-    Path(__file__).resolve().parent.parent.parent / "hooks" / "lights-on-oracle-pre.sh"
-)
+HOOK_SCRIPT = Path(__file__).resolve().parent.parent.parent / "hooks" / "lights-on-oracle-pre.sh"
 SESSION_ID = "behave-test-session"
 
 
@@ -45,9 +43,7 @@ def _resolve(context, path: str) -> str:
 
 def _write_file_cache(context, rel_path: str, content: bytes, disk_sha: str) -> None:
     full = _resolve(context, rel_path)
-    context.hook_store.upsert_file_cache(
-        full, content, disk_sha, disk_sha, int(time.time())
-    )
+    context.hook_store.upsert_file_cache(full, content, disk_sha, disk_sha, int(time.time()))
 
 
 def _record_session(context, rel_path: str) -> None:
@@ -124,19 +120,13 @@ def step_agent_builtin_read(context, rel_path):
     _record_session(context, rel_path)
 
 
-@given(
-    "session_files contains a row for the current session and "
-    '"{rel_path}"'
-)
+@given('session_files contains a row for the current session and "{rel_path}"')
 def step_session_files_has_row(context, rel_path):
     _make_file(context, rel_path)
     _record_session(context, rel_path)
 
 
-@given(
-    "session_files contains a row for the current session and the resolved target "
-    '"{rel_path}"'
-)
+@given('session_files contains a row for the current session and the resolved target "{rel_path}"')
 def step_session_files_has_resolved_target(context, rel_path):
     full = _make_file(context, rel_path)
     content = Path(full).read_bytes()
@@ -159,9 +149,7 @@ def step_symlink(context, symlink_path, target):
     sym_full.symlink_to(target_full)
 
 
-@given(
-    'file_cache.disk_sha256 for "{rel_path}" equals its current on-disk SHA-256'
-)
+@given('file_cache.disk_sha256 for "{rel_path}" equals its current on-disk SHA-256')
 def step_disk_sha_matches(context, rel_path):
     full = _resolve(context, rel_path)
     content = Path(full).read_bytes()
@@ -179,9 +167,7 @@ def step_disk_sha_still_matches(context, rel_path):
     step_disk_sha_matches(context, rel_path)
 
 
-@given(
-    'file_cache.disk_sha256 for "{rel_path}" differs from its current on-disk SHA-256'
-)
+@given('file_cache.disk_sha256 for "{rel_path}" differs from its current on-disk SHA-256')
 def step_disk_sha_differs(context, rel_path):
     # Ensure the file exists, then store a stale SHA in file_cache
     _make_file(context, rel_path)
@@ -191,9 +177,7 @@ def step_disk_sha_differs(context, rel_path):
     context.hook_store.upsert_file_cache(full, content, stale_sha, stale_sha, int(time.time()))
 
 
-@given(
-    'file_cache contains "{rel_path}" with a matching disk_sha256 from a prior session'
-)
+@given('file_cache contains "{rel_path}" with a matching disk_sha256 from a prior session')
 def step_cross_session_cache(context, rel_path):
     full = _make_file(context, rel_path)
     content = Path(full).read_bytes()
@@ -213,16 +197,12 @@ def step_agent_just_called_read(context, rel_path):
     _make_file(context, rel_path)
 
 
-@given(
-    "the ingest worker has not yet inserted into session_files for that Read"
-)
+@given("the ingest worker has not yet inserted into session_files for that Read")
 def step_ingest_not_yet(context):
     pass  # No row recorded
 
 
-@given(
-    "the ingest worker has consumed the event and inserted into session_files"
-)
+@given("the ingest worker has consumed the event and inserted into session_files")
 def step_ingest_consumed(context):
     # already recorded above by step_agent_builtin_read
     pass
@@ -240,17 +220,12 @@ def step_db_missing(context):
     context.hook_resolved_target = project
 
 
-@given(
-    'the agent first called Read on "{rel_path}" with offset 0 and limit 100'
-)
+@given('the agent first called Read on "{rel_path}" with offset 0 and limit 100')
 def step_agent_partial_read(context, rel_path):
     _make_file(context, rel_path)
 
 
-@given(
-    "the ingest worker added a row for the current session and "
-    '"{rel_path}"'
-)
+@given('the ingest worker added a row for the current session and "{rel_path}"')
 def step_ingest_added_row(context, rel_path):
     full = _resolve(context, rel_path)
     content = Path(full).read_bytes()
@@ -259,9 +234,7 @@ def step_ingest_added_row(context, rel_path):
     _record_session(context, rel_path)
 
 
-@when(
-    'the hook fires for Read on "{rel_path}" with no offset or limit'
-)
+@when('the hook fires for Read on "{rel_path}" with no offset or limit')
 def step_when_read_no_partial(context, rel_path):
     full = _resolve(context, rel_path)
     payload = {
@@ -277,9 +250,7 @@ def step_when_read(context, rel_path):
     step_when_read_no_partial(context, rel_path)
 
 
-@when(
-    'the hook fires for Read on "{rel_path}" with offset {offset:d} and limit {limit:d}'
-)
+@when('the hook fires for Read on "{rel_path}" with offset {offset:d} and limit {limit:d}')
 def step_when_read_partial(context, rel_path, offset, limit):
     full = _resolve(context, rel_path)
     payload = {
@@ -323,9 +294,7 @@ def step_when_grep(context, pattern):
     _run_hook(context, payload)
 
 
-@when(
-    'inspecting the hook source for "{a}", "{b}", and "{c}"'
-)
+@when('inspecting the hook source for "{a}", "{b}", and "{c}"')
 def step_inspect_hook_source(context, a, b, c):
     text = HOOK_SCRIPT.read_text()
     context.hook_source_matches = [s for s in (a, b, c) if s in text]
@@ -342,24 +311,18 @@ def step_then_exit(context, code):
 
 @then('stderr contains "{text}"')
 def step_then_stderr_contains(context, text):
-    assert text in context.hook_stderr, (
-        f"Expected '{text}' in stderr; got: {context.hook_stderr!r}"
-    )
+    assert text in context.hook_stderr, f"Expected '{text}' in stderr; got: {context.hook_stderr!r}"
 
 
 @then('stderr contains the resolved path of "{rel_path}"')
 def step_then_stderr_contains_resolved_path(context, rel_path):
     full = _resolve(context, rel_path)
-    assert full in context.hook_stderr, (
-        f"Expected '{full}' in stderr; got: {context.hook_stderr!r}"
-    )
+    assert full in context.hook_stderr, f"Expected '{full}' in stderr; got: {context.hook_stderr!r}"
 
 
 @then('stdout contains "{text}"')
 def step_then_stdout_contains(context, text):
-    assert text in context.hook_stdout, (
-        f"Expected '{text}' in stdout; got: {context.hook_stdout!r}"
-    )
+    assert text in context.hook_stdout, f"Expected '{text}' in stdout; got: {context.hook_stdout!r}"
 
 
 @then("no matches are found")

--- a/features/steps/hook_steps.py
+++ b/features/steps/hook_steps.py
@@ -54,6 +54,8 @@ def _record_session(context, rel_path: str) -> None:
 def _run_hook(context, payload: dict, file_path_for_resolve: str | None = None) -> None:
     env = os.environ.copy()
     env["ORACLE_DIR"] = str(context.hook_oracle_dir)
+    if getattr(context, "hook_path_override", None) is not None:
+        env["PATH"] = context.hook_path_override
     if hasattr(context, "hook_store"):
         context.hook_store.close()
         context.hook_store = OracleStore(context.hook_db_path)
@@ -223,6 +225,72 @@ def step_db_missing(context):
 @given('the agent first called Read on "{rel_path}" with offset 0 and limit 100')
 def step_agent_partial_read(context, rel_path):
     _make_file(context, rel_path)
+
+
+@given("neither timeout nor gtimeout is on PATH")
+def step_no_timeout_binary(context):
+    # Build a tmp dir with only the helpers the hook genuinely needs (jq,
+    # sqlite3, shasum, awk, sed, mktemp, realpath, dirname, printf, cat)
+    # but explicitly exclude `timeout` and `gtimeout` so the fallback path
+    # is exercised end-to-end.
+    isolated = context.tmp_dir / "no-timeout-bin"
+    isolated.mkdir(exist_ok=True)
+    helpers = [
+        "jq",
+        "sqlite3",
+        "shasum",
+        "awk",
+        "sed",
+        "mktemp",
+        "realpath",
+        "dirname",
+        "printf",
+        "cat",
+        "bash",
+        "head",
+        "rm",
+    ]
+    seen: set[str] = set()
+    for path_dir in os.environ.get("PATH", "").split(os.pathsep):
+        if not path_dir:
+            continue
+        for helper in helpers:
+            if helper in seen:
+                continue
+            candidate = Path(path_dir) / helper
+            if candidate.exists():
+                link = isolated / helper
+                if not link.exists():
+                    link.symlink_to(candidate)
+                seen.add(helper)
+    context.hook_path_override = str(isolated)
+
+
+@then("stderr is empty")
+def step_then_stderr_empty(context):
+    assert context.hook_stderr == "", f"Expected empty stderr, got: {context.hook_stderr!r}"
+
+
+@when("inspecting the hook source for the timeout fallback")
+def step_inspect_timeout_fallback(context):
+    context.hook_source_text = HOOK_SCRIPT.read_text()
+
+
+@then('the hook source declares both "timeout" and "gtimeout" as candidates')
+def step_then_source_has_candidates(context):
+    src = context.hook_source_text
+    assert "command -v timeout" in src, "Hook does not probe for `timeout` via command -v"
+    assert "command -v gtimeout" in src, "Hook does not probe for `gtimeout` via command -v"
+
+
+@then("the hook source uses the resolved timeout command via a variable")
+def step_then_source_uses_variable(context):
+    src = context.hook_source_text
+    assert "TIMEOUT_CMD=" in src, "Hook does not assign TIMEOUT_CMD"
+    assert '"$TIMEOUT_CMD"' in src, (
+        "Hook does not invoke timeout indirectly via $TIMEOUT_CMD — "
+        "the literal `timeout` invocation will fail on stock macOS."
+    )
 
 
 @given('the ingest worker added a row for the current session and "{rel_path}"')

--- a/hooks/lights-on-oracle-pre.sh
+++ b/hooks/lights-on-oracle-pre.sh
@@ -55,7 +55,21 @@ project_db_path() {
 TOOL_INPUT=$(cat 2>/dev/null) || true
 [[ -z "$TOOL_INPUT" ]] && exit 0
 
-TOOL_NAME=$(printf '%s' "$TOOL_INPUT" | jq -r '.tool_name // empty' 2>/dev/null) || exit 0
+# Single jq call extracts everything we might need: tool_name, session_id,
+# file_path, and presence flags for offset/limit. Tab-separated values are
+# split by IFS read below. Each tab-separated cell is "-" when absent so
+# bash can detect missing fields without ambiguity.
+JQ_OUT=$(printf '%s' "$TOOL_INPUT" | jq -r '
+    [
+        .tool_name // "",
+        .session_id // "",
+        .tool_input.file_path // "",
+        (if (.tool_input | has("offset")) then "1" else "" end),
+        (if (.tool_input | has("limit")) then "1" else "" end)
+    ] | @tsv
+' 2>/dev/null) || exit 0
+
+IFS=$'\t' read -r TOOL_NAME SESSION_ID FILE_PATH HAS_OFFSET HAS_LIMIT <<< "$JQ_OUT"
 [[ -z "$TOOL_NAME" ]] && exit 0
 
 # --- Grep: advisory only ---
@@ -75,15 +89,10 @@ if [[ "$TOOL_NAME" != "Read" ]]; then
     exit 0
 fi
 
-SESSION_ID=$(printf '%s' "$TOOL_INPUT" | jq -r '.session_id // empty' 2>/dev/null) || exit 0
 [[ -z "$SESSION_ID" ]] && exit 0
-
-FILE_PATH=$(printf '%s' "$TOOL_INPUT" | jq -r '.tool_input.file_path // empty' 2>/dev/null) || exit 0
 [[ -z "$FILE_PATH" ]] && exit 0
 
 # Partial read (non-default offset or limit) → allow.
-HAS_OFFSET=$(printf '%s' "$TOOL_INPUT" | jq -r '(.tool_input.offset // empty) | tostring' 2>/dev/null) || HAS_OFFSET=""
-HAS_LIMIT=$(printf '%s' "$TOOL_INPUT" | jq -r '(.tool_input.limit // empty) | tostring' 2>/dev/null) || HAS_LIMIT=""
 if [[ -n "$HAS_OFFSET" || -n "$HAS_LIMIT" ]]; then
     exit 0
 fi
@@ -100,10 +109,18 @@ PROJECT_ROOT=$(find_project_root "$RESOLVED_PATH") || exit 0
 DB_PATH=$(project_db_path "$PROJECT_ROOT")
 [[ -f "$DB_PATH" ]] || exit 0
 
-# Lookup cached disk_sha256 for (session_id, path) — only returns a row
-# when the file was both served this session AND has a file_cache entry.
+# Lookup cached disk_sha256 for (session_id, path) AND compute the on-disk
+# SHA in parallel. Both are independent and the bottleneck is fork/exec
+# overhead, so running shasum in the background while sqlite3 executes
+# halves the serial cost on the hot path.
 ESCAPED_SESSION=$(printf '%s' "$SESSION_ID" | sed "s/'/''/g")
 ESCAPED_PATH=$(printf '%s' "$RESOLVED_PATH" | sed "s/'/''/g")
+DISK_SHA_FILE=$(mktemp -t aylo-disk-sha.XXXXXX) || exit 0
+trap 'rm -f "$DISK_SHA_FILE"' EXIT
+
+(shasum -a 256 "$RESOLVED_PATH" 2>/dev/null | awk '{print $1}' > "$DISK_SHA_FILE") &
+DISK_SHA_PID=$!
+
 CACHED_SHA=$(timeout "$SQLITE_QUERY_TIMEOUT_S" sqlite3 \
     -readonly \
     -batch \
@@ -111,12 +128,15 @@ CACHED_SHA=$(timeout "$SQLITE_QUERY_TIMEOUT_S" sqlite3 \
     -list \
     -cmd ".timeout $SQLITE_BUSY_TIMEOUT_MS" \
     "$DB_PATH" \
-    "SELECT f.disk_sha256 FROM file_cache f JOIN session_files s ON s.path = f.path WHERE s.session_id = '$ESCAPED_SESSION' AND f.path = '$ESCAPED_PATH';" 2>/dev/null) || exit 0
+    "SELECT f.disk_sha256 FROM file_cache f JOIN session_files s ON s.path = f.path WHERE s.session_id = '$ESCAPED_SESSION' AND f.path = '$ESCAPED_PATH';" 2>/dev/null) || {
+    wait "$DISK_SHA_PID" 2>/dev/null || true
+    exit 0
+}
+
+wait "$DISK_SHA_PID" 2>/dev/null || true
+DISK_SHA=$(<"$DISK_SHA_FILE")
 
 [[ -z "$CACHED_SHA" || "$CACHED_SHA" == "NULL" ]] && exit 0
-
-# Compute current on-disk SHA-256. Failure (file deleted, permissions) → allow.
-DISK_SHA=$(shasum -a 256 "$RESOLVED_PATH" 2>/dev/null | awk '{print $1}') || exit 0
 [[ -z "$DISK_SHA" ]] && exit 0
 
 # Block iff cached disk SHA matches current on-disk SHA.

--- a/hooks/lights-on-oracle-pre.sh
+++ b/hooks/lights-on-oracle-pre.sh
@@ -15,6 +15,18 @@ PROJECT_MARKERS=(.git package.json pyproject.toml go.mod Cargo.toml)
 SQLITE_BUSY_TIMEOUT_MS=30
 SQLITE_QUERY_TIMEOUT_S=2
 
+# Resolve a portable timer. macOS does not ship GNU `timeout` by default;
+# `brew install coreutils` provides `gtimeout`. If neither is present the
+# Read binary-block path will fail open silently (see below) — Bash and
+# Grep advisories do not need a timer and stay functional regardless.
+if command -v timeout >/dev/null 2>&1; then
+    TIMEOUT_CMD=timeout
+elif command -v gtimeout >/dev/null 2>&1; then
+    TIMEOUT_CMD=gtimeout
+else
+    TIMEOUT_CMD=
+fi
+
 emit_advisory() {
     local msg="$1"
     jq -n --arg q "$msg" '{
@@ -89,6 +101,11 @@ if [[ "$TOOL_NAME" != "Read" ]]; then
     exit 0
 fi
 
+# No portable timer means we cannot enforce the SQLite query timeout, so
+# the Read binary block is unavailable on this platform. Fail open
+# silently — Bash and Grep advisories already ran above.
+[[ -z "$TIMEOUT_CMD" ]] && exit 0
+
 [[ -z "$SESSION_ID" ]] && exit 0
 [[ -z "$FILE_PATH" ]] && exit 0
 
@@ -121,7 +138,7 @@ trap 'rm -f "$DISK_SHA_FILE"' EXIT
 (shasum -a 256 "$RESOLVED_PATH" 2>/dev/null | awk '{print $1}' > "$DISK_SHA_FILE") &
 DISK_SHA_PID=$!
 
-CACHED_SHA=$(timeout "$SQLITE_QUERY_TIMEOUT_S" sqlite3 \
+CACHED_SHA=$("$TIMEOUT_CMD" "$SQLITE_QUERY_TIMEOUT_S" sqlite3 \
     -readonly \
     -batch \
     -noheader \

--- a/hooks/lights-on-oracle-pre.sh
+++ b/hooks/lights-on-oracle-pre.sh
@@ -1,32 +1,21 @@
 #!/bin/bash
 # "Are Your Lights On?" — PreToolUse:Read/Grep/Bash
-# Redirects the agent to oracle_* tools instead of built-in Read/Grep/Bash.
-# Uses a per-session counter to escalate from nudge → warning → demand.
-# Always exits 0 (non-blocking), but the message gets harder to ignore.
+# Read: binary block when the file is provably redundant within the current
+#   Claude Code session — i.e., (session_id, path) is in session_files AND
+#   file_cache.disk_sha256 matches the on-disk SHA-256. Any other case
+#   exits 0 (allow). Failure modes (timeout, missing DB, malformed input,
+#   non-tracked path, partial read) all exit 0.
+# Grep / Bash: advisory behavior only — emit additionalContext nudging
+#   toward oracle_grep / oracle_run. No escalation, no blocking.
 
 set -euo pipefail
 
-# --- Per-session escalation counter ---
-COUNTER_DIR="${TMPDIR:-/tmp}/oracle-aylo-$$"
-mkdir -p "$COUNTER_DIR" 2>/dev/null || true
+ORACLE_DIR="${ORACLE_DIR:-$HOME/.project-oracle}"
+PROJECT_MARKERS=(.git package.json pyproject.toml go.mod Cargo.toml)
+SQLITE_BUSY_TIMEOUT_MS=30
+SQLITE_QUERY_TIMEOUT_S=2
 
-get_count() {
-    local tool="$1"
-    local f="$COUNTER_DIR/$tool"
-    if [[ -f "$f" ]]; then
-        read -r n < "$f"
-        echo "$((n + 1))"
-    else
-        echo "1"
-    fi
-}
-
-set_count() {
-    local tool="$1" count="$2"
-    echo "$count" > "$COUNTER_DIR/$tool" 2>/dev/null || true
-}
-
-emit_pre() {
+emit_advisory() {
     local msg="$1"
     jq -n --arg q "$msg" '{
       hookSpecificOutput: {
@@ -37,48 +26,104 @@ emit_pre() {
     }'
 }
 
+find_project_root() {
+    # Walk up from $1 looking for any PROJECT_MARKER. Echo the root or
+    # nothing if not found.
+    local current="$1"
+    [[ -d "$current" ]] || current="$(dirname "$current")"
+    while [[ -n "$current" && "$current" != "/" ]]; do
+        for marker in "${PROJECT_MARKERS[@]}"; do
+            if [[ -e "$current/$marker" ]]; then
+                echo "$current"
+                return 0
+            fi
+        done
+        current="$(dirname "$current")"
+    done
+    return 1
+}
+
+project_db_path() {
+    # Echo the per-project SQLite database path for project root $1.
+    # Returns 0 even if the file doesn't exist; callers must check.
+    local root="$1"
+    local pid
+    pid="$(printf '%s' "$root" | shasum -a 256 | head -c 8)"
+    echo "$ORACLE_DIR/projects/$pid/oracle.db"
+}
+
 TOOL_INPUT=$(cat 2>/dev/null) || true
 [[ -z "$TOOL_INPUT" ]] && exit 0
 
-TOOL_NAME=$(echo "$TOOL_INPUT" | jq -r '.tool_name // empty' 2>/dev/null) || true
+TOOL_NAME=$(printf '%s' "$TOOL_INPUT" | jq -r '.tool_name // empty' 2>/dev/null) || exit 0
 [[ -z "$TOOL_NAME" ]] && exit 0
 
-# --- Read ---
-if [[ "$TOOL_NAME" == "Read" ]]; then
-    N=$(get_count Read)
-    set_count Read "$N"
-    if (( N <= 2 )); then
-        emit_pre "STOP. Check: do you already have this file's content in your conversation context? If yes, you don't need to read it again. If no, use oracle_read (mcp__project-oracle__oracle_read) instead of Read — it caches the content so your next read costs 3 tokens instead of hundreds."
-    elif (( N <= 5 )); then
-        emit_pre "This is Read call #$N this session. You have used Read $N times instead of oracle_read. Each one adds hundreds of tokens to context that oracle_read would have served from cache. Use oracle_read for file reads — it returns full content on first call and compact deltas on repeats."
-    else
-        emit_pre "Read call #$N. You are consistently ignoring oracle_read. Every Read call bypasses the cache and wastes tokens. The oracle_read tool (mcp__project-oracle__oracle_read) does the same thing but tracks what you've seen. USE IT."
-    fi
-    exit 0
-fi
-
-# --- Grep ---
+# --- Grep: advisory only ---
 if [[ "$TOOL_NAME" == "Grep" ]]; then
-    N=$(get_count Grep)
-    set_count Grep "$N"
-    if (( N <= 2 )); then
-        emit_pre "STOP. Use oracle_grep (mcp__project-oracle__oracle_grep) instead of Grep. It returns the same results but caches them — if you search for the same pattern again, you get the answer instantly instead of re-scanning the codebase."
-    else
-        emit_pre "Grep call #$N. Use oracle_grep (mcp__project-oracle__oracle_grep). It caches results so repeated searches cost nothing."
-    fi
+    emit_advisory "Use oracle_grep (mcp__project-oracle__oracle_grep) instead of Grep. It returns the same results but caches them — repeated searches cost nothing."
     exit 0
 fi
 
-# --- Bash ---
+# --- Bash: advisory only ---
 if [[ "$TOOL_NAME" == "Bash" ]]; then
-    N=$(get_count Bash)
-    set_count Bash "$N"
-    if (( N <= 2 )); then
-        emit_pre "Check: is this a test/lint/build command? If so, use oracle_run (mcp__project-oracle__oracle_run) instead — it caches results keyed by source file hashes. If the code hasn't changed since last run, you get the cached result instantly instead of waiting for the command to execute."
-    else
-        emit_pre "Bash call #$N. For test/lint/build commands, oracle_run (mcp__project-oracle__oracle_run) returns cached results when source files haven't changed. Use it."
-    fi
+    emit_advisory "Check: is this a test/lint/build command? If so, use oracle_run (mcp__project-oracle__oracle_run) instead — it caches results keyed by source file hashes. If the code hasn't changed since last run, you get the cached result instantly instead of waiting for the command to execute."
     exit 0
+fi
+
+# --- Read: binary block on provably redundant reads ---
+if [[ "$TOOL_NAME" != "Read" ]]; then
+    exit 0
+fi
+
+SESSION_ID=$(printf '%s' "$TOOL_INPUT" | jq -r '.session_id // empty' 2>/dev/null) || exit 0
+[[ -z "$SESSION_ID" ]] && exit 0
+
+FILE_PATH=$(printf '%s' "$TOOL_INPUT" | jq -r '.tool_input.file_path // empty' 2>/dev/null) || exit 0
+[[ -z "$FILE_PATH" ]] && exit 0
+
+# Partial read (non-default offset or limit) → allow.
+HAS_OFFSET=$(printf '%s' "$TOOL_INPUT" | jq -r '(.tool_input.offset // empty) | tostring' 2>/dev/null) || HAS_OFFSET=""
+HAS_LIMIT=$(printf '%s' "$TOOL_INPUT" | jq -r '(.tool_input.limit // empty) | tostring' 2>/dev/null) || HAS_LIMIT=""
+if [[ -n "$HAS_OFFSET" || -n "$HAS_LIMIT" ]]; then
+    exit 0
+fi
+
+# Resolve path (canonicalize symlinks). If realpath fails (worktree
+# deleted, dangling symlink) → allow.
+RESOLVED_PATH=$(realpath "$FILE_PATH" 2>/dev/null) || exit 0
+[[ -z "$RESOLVED_PATH" ]] && exit 0
+
+# Path must be inside a tracked project root.
+PROJECT_ROOT=$(find_project_root "$RESOLVED_PATH") || exit 0
+[[ -z "$PROJECT_ROOT" ]] && exit 0
+
+DB_PATH=$(project_db_path "$PROJECT_ROOT")
+[[ -f "$DB_PATH" ]] || exit 0
+
+# Lookup cached disk_sha256 for (session_id, path) — only returns a row
+# when the file was both served this session AND has a file_cache entry.
+ESCAPED_SESSION=$(printf '%s' "$SESSION_ID" | sed "s/'/''/g")
+ESCAPED_PATH=$(printf '%s' "$RESOLVED_PATH" | sed "s/'/''/g")
+CACHED_SHA=$(timeout "$SQLITE_QUERY_TIMEOUT_S" sqlite3 \
+    -readonly \
+    -batch \
+    -noheader \
+    -list \
+    -cmd ".timeout $SQLITE_BUSY_TIMEOUT_MS" \
+    "$DB_PATH" \
+    "SELECT f.disk_sha256 FROM file_cache f JOIN session_files s ON s.path = f.path WHERE s.session_id = '$ESCAPED_SESSION' AND f.path = '$ESCAPED_PATH';" 2>/dev/null) || exit 0
+
+[[ -z "$CACHED_SHA" || "$CACHED_SHA" == "NULL" ]] && exit 0
+
+# Compute current on-disk SHA-256. Failure (file deleted, permissions) → allow.
+DISK_SHA=$(shasum -a 256 "$RESOLVED_PATH" 2>/dev/null | awk '{print $1}') || exit 0
+[[ -z "$DISK_SHA" ]] && exit 0
+
+# Block iff cached disk SHA matches current on-disk SHA.
+if [[ "$CACHED_SHA" == "$DISK_SHA" ]]; then
+    printf 'File unchanged since last read: %s\nThe agent already has this content from earlier in the session. Skip this Read; reuse the prior content. If the cached content was lost, use oracle_read for a compact delta.\n' \
+        "$RESOLVED_PATH" >&2
+    exit 2
 fi
 
 exit 0

--- a/hooks/lights-on-oracle-pre.sh
+++ b/hooks/lights-on-oracle-pre.sh
@@ -64,103 +64,112 @@ project_db_path() {
     echo "$ORACLE_DIR/projects/$pid/oracle.db"
 }
 
-TOOL_INPUT=$(cat 2>/dev/null) || true
-[[ -z "$TOOL_INPUT" ]] && exit 0
+_aylo_main() {
+    TOOL_INPUT=$(cat 2>/dev/null) || true
+    [[ -z "$TOOL_INPUT" ]] && exit 0
 
-# Single jq call extracts everything we might need: tool_name, session_id,
-# file_path, and presence flags for offset/limit. Tab-separated values are
-# split by IFS read below. Each tab-separated cell is "-" when absent so
-# bash can detect missing fields without ambiguity.
-JQ_OUT=$(printf '%s' "$TOOL_INPUT" | jq -r '
-    [
-        .tool_name // "",
-        .session_id // "",
-        .tool_input.file_path // "",
-        (if (.tool_input | has("offset")) then "1" else "" end),
-        (if (.tool_input | has("limit")) then "1" else "" end)
-    ] | @tsv
-' 2>/dev/null) || exit 0
+    # Single jq call extracts everything we might need: tool_name, session_id,
+    # file_path, and presence flags for offset/limit. Tab-separated values are
+    # split by IFS read below. Each tab-separated cell is "-" when absent so
+    # bash can detect missing fields without ambiguity.
+    JQ_OUT=$(printf '%s' "$TOOL_INPUT" | jq -r '
+        [
+            .tool_name // "",
+            .session_id // "",
+            .tool_input.file_path // "",
+            (if (.tool_input | has("offset")) then "1" else "" end),
+            (if (.tool_input | has("limit")) then "1" else "" end)
+        ] | @tsv
+    ' 2>/dev/null) || exit 0
 
-IFS=$'\t' read -r TOOL_NAME SESSION_ID FILE_PATH HAS_OFFSET HAS_LIMIT <<< "$JQ_OUT"
-[[ -z "$TOOL_NAME" ]] && exit 0
+    IFS=$'\t' read -r TOOL_NAME SESSION_ID FILE_PATH HAS_OFFSET HAS_LIMIT <<< "$JQ_OUT"
+    [[ -z "$TOOL_NAME" ]] && exit 0
 
-# --- Grep: advisory only ---
-if [[ "$TOOL_NAME" == "Grep" ]]; then
-    emit_advisory "Use oracle_grep (mcp__project-oracle__oracle_grep) instead of Grep. It returns the same results but caches them — repeated searches cost nothing."
-    exit 0
-fi
+    # --- Grep: advisory only ---
+    if [[ "$TOOL_NAME" == "Grep" ]]; then
+        emit_advisory "Use oracle_grep (mcp__project-oracle__oracle_grep) instead of Grep. It returns the same results but caches them — repeated searches cost nothing."
+        exit 0
+    fi
 
-# --- Bash: advisory only ---
-if [[ "$TOOL_NAME" == "Bash" ]]; then
-    emit_advisory "Check: is this a test/lint/build command? If so, use oracle_run (mcp__project-oracle__oracle_run) instead — it caches results keyed by source file hashes. If the code hasn't changed since last run, you get the cached result instantly instead of waiting for the command to execute."
-    exit 0
-fi
+    # --- Bash: advisory only ---
+    if [[ "$TOOL_NAME" == "Bash" ]]; then
+        emit_advisory "Check: is this a test/lint/build command? If so, use oracle_run (mcp__project-oracle__oracle_run) instead — it caches results keyed by source file hashes. If the code hasn't changed since last run, you get the cached result instantly instead of waiting for the command to execute."
+        exit 0
+    fi
 
-# --- Read: binary block on provably redundant reads ---
-if [[ "$TOOL_NAME" != "Read" ]]; then
-    exit 0
-fi
+    # --- Read: binary block on provably redundant reads ---
+    if [[ "$TOOL_NAME" != "Read" ]]; then
+        exit 0
+    fi
 
-# No portable timer means we cannot enforce the SQLite query timeout, so
-# the Read binary block is unavailable on this platform. Fail open
-# silently — Bash and Grep advisories already ran above.
-[[ -z "$TIMEOUT_CMD" ]] && exit 0
+    # No portable timer means we cannot enforce the SQLite query timeout, so
+    # the Read binary block is unavailable on this platform. Fail open
+    # silently — Bash and Grep advisories already ran above.
+    [[ -z "$TIMEOUT_CMD" ]] && exit 0
 
-[[ -z "$SESSION_ID" ]] && exit 0
-[[ -z "$FILE_PATH" ]] && exit 0
+    [[ -z "$SESSION_ID" ]] && exit 0
+    [[ -z "$FILE_PATH" ]] && exit 0
 
-# Partial read (non-default offset or limit) → allow.
-if [[ -n "$HAS_OFFSET" || -n "$HAS_LIMIT" ]]; then
-    exit 0
-fi
+    # Partial read (non-default offset or limit) → allow.
+    if [[ -n "$HAS_OFFSET" || -n "$HAS_LIMIT" ]]; then
+        exit 0
+    fi
 
-# Resolve path (canonicalize symlinks). If realpath fails (worktree
-# deleted, dangling symlink) → allow.
-RESOLVED_PATH=$(realpath "$FILE_PATH" 2>/dev/null) || exit 0
-[[ -z "$RESOLVED_PATH" ]] && exit 0
+    # Resolve path (canonicalize symlinks). If realpath fails (worktree
+    # deleted, dangling symlink) → allow.
+    RESOLVED_PATH=$(realpath "$FILE_PATH" 2>/dev/null) || exit 0
+    [[ -z "$RESOLVED_PATH" ]] && exit 0
 
-# Path must be inside a tracked project root.
-PROJECT_ROOT=$(find_project_root "$RESOLVED_PATH") || exit 0
-[[ -z "$PROJECT_ROOT" ]] && exit 0
+    # Path must be inside a tracked project root.
+    PROJECT_ROOT=$(find_project_root "$RESOLVED_PATH") || exit 0
+    [[ -z "$PROJECT_ROOT" ]] && exit 0
 
-DB_PATH=$(project_db_path "$PROJECT_ROOT")
-[[ -f "$DB_PATH" ]] || exit 0
+    DB_PATH=$(project_db_path "$PROJECT_ROOT")
+    [[ -f "$DB_PATH" ]] || exit 0
 
-# Lookup cached disk_sha256 for (session_id, path) AND compute the on-disk
-# SHA in parallel. Both are independent and the bottleneck is fork/exec
-# overhead, so running shasum in the background while sqlite3 executes
-# halves the serial cost on the hot path.
-ESCAPED_SESSION=$(printf '%s' "$SESSION_ID" | sed "s/'/''/g")
-ESCAPED_PATH=$(printf '%s' "$RESOLVED_PATH" | sed "s/'/''/g")
-DISK_SHA_FILE=$(mktemp -t aylo-disk-sha.XXXXXX) || exit 0
-trap 'rm -f "$DISK_SHA_FILE"' EXIT
+    # Lookup cached disk_sha256 for (session_id, path) AND compute the on-disk
+    # SHA in parallel. Both are independent and the bottleneck is fork/exec
+    # overhead, so running shasum in the background while sqlite3 executes
+    # halves the serial cost on the hot path.
+    ESCAPED_SESSION=$(printf '%s' "$SESSION_ID" | sed "s/'/''/g")
+    ESCAPED_PATH=$(printf '%s' "$RESOLVED_PATH" | sed "s/'/''/g")
+    DISK_SHA_FILE=$(mktemp -t aylo-disk-sha.XXXXXX) || exit 0
+    trap 'rm -f "$DISK_SHA_FILE"' EXIT
 
-(shasum -a 256 "$RESOLVED_PATH" 2>/dev/null | awk '{print $1}' > "$DISK_SHA_FILE") &
-DISK_SHA_PID=$!
+    (shasum -a 256 "$RESOLVED_PATH" 2>/dev/null | awk '{print $1}' > "$DISK_SHA_FILE") &
+    DISK_SHA_PID=$!
 
-CACHED_SHA=$("$TIMEOUT_CMD" "$SQLITE_QUERY_TIMEOUT_S" sqlite3 \
-    -readonly \
-    -batch \
-    -noheader \
-    -list \
-    -cmd ".timeout $SQLITE_BUSY_TIMEOUT_MS" \
-    "$DB_PATH" \
-    "SELECT f.disk_sha256 FROM file_cache f JOIN session_files s ON s.path = f.path WHERE s.session_id = '$ESCAPED_SESSION' AND f.path = '$ESCAPED_PATH';" 2>/dev/null) || {
+    CACHED_SHA=$("$TIMEOUT_CMD" "$SQLITE_QUERY_TIMEOUT_S" sqlite3 \
+        -readonly \
+        -batch \
+        -noheader \
+        -list \
+        -cmd ".timeout $SQLITE_BUSY_TIMEOUT_MS" \
+        "$DB_PATH" \
+        "SELECT f.disk_sha256 FROM file_cache f JOIN session_files s ON s.path = f.path WHERE s.session_id = '$ESCAPED_SESSION' AND f.path = '$ESCAPED_PATH';" 2>/dev/null) || {
+        wait "$DISK_SHA_PID" 2>/dev/null || true
+        exit 0
+    }
+
     wait "$DISK_SHA_PID" 2>/dev/null || true
+    DISK_SHA=$(<"$DISK_SHA_FILE")
+
+    [[ -z "$CACHED_SHA" || "$CACHED_SHA" == "NULL" ]] && exit 0
+    [[ -z "$DISK_SHA" ]] && exit 0
+
+    # Block iff cached disk SHA matches current on-disk SHA.
+    if [[ "$CACHED_SHA" == "$DISK_SHA" ]]; then
+        printf 'File unchanged since last read: %s\nThe agent already has this content from earlier in the session. Skip this Read; reuse the prior content. If the cached content was lost, use oracle_read for a compact delta.\n' \
+            "$RESOLVED_PATH" >&2
+        exit 2
+    fi
+
     exit 0
 }
 
-wait "$DISK_SHA_PID" 2>/dev/null || true
-DISK_SHA=$(<"$DISK_SHA_FILE")
-
-[[ -z "$CACHED_SHA" || "$CACHED_SHA" == "NULL" ]] && exit 0
-[[ -z "$DISK_SHA" ]] && exit 0
-
-# Block iff cached disk SHA matches current on-disk SHA.
-if [[ "$CACHED_SHA" == "$DISK_SHA" ]]; then
-    printf 'File unchanged since last read: %s\nThe agent already has this content from earlier in the session. Skip this Read; reuse the prior content. If the cached content was lost, use oracle_read for a compact delta.\n' \
-        "$RESOLVED_PATH" >&2
-    exit 2
+# Run main logic only when executed directly. Sourcing the script (e.g., from
+# tests/test_project_hash_parity.py) loads the helper functions without firing
+# the hook's main pipeline.
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    _aylo_main "$@"
 fi
-
-exit 0

--- a/scripts/bench_hook.sh
+++ b/scripts/bench_hook.sh
@@ -1,0 +1,187 @@
+#!/bin/bash
+# Benchmarks the lights-on-oracle-pre.sh PreToolUse hook on a redundant
+# Read input. Builds a SQLite fixture with at least 1000 file_cache rows
+# and 1000 session_files rows distributed across 10+ session_ids, then
+# runs the hook 100 times against the same redundant-Read input and
+# reports p50 / p99 wall-clock times.
+#
+# Per the issue AC: p50 < 30ms and p99 < 50ms on an M-series Mac.
+# CI does not enforce these budgets; the script is for manual verification.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+HOOK="$REPO_ROOT/hooks/lights-on-oracle-pre.sh"
+
+if [[ ! -x "$HOOK" ]]; then
+    echo "Hook not executable: $HOOK" >&2
+    exit 1
+fi
+
+WORKDIR="$(mktemp -d -t bench-hook.XXXXXX)"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+PROJECT_DIR="$WORKDIR/project"
+ORACLE_DIR="$WORKDIR/oracle"
+mkdir -p "$PROJECT_DIR/src" "$ORACLE_DIR/projects"
+(cd "$PROJECT_DIR" && git init -q)
+
+PYTHON_BIN="${PYTHON_BIN:-python3}"
+"$PYTHON_BIN" - "$PROJECT_DIR" "$ORACLE_DIR" <<'PY'
+import hashlib
+import sqlite3
+import sys
+import time
+from pathlib import Path
+
+project_dir = Path(sys.argv[1]).resolve()
+oracle_dir = Path(sys.argv[2]).resolve()
+
+target_rel = "src/foo.py"
+target_path = project_dir / target_rel
+target_path.write_text("print('benchmark target')\n")
+target_full = str(target_path.resolve())
+target_sha = hashlib.sha256(target_path.read_bytes()).hexdigest()
+
+pid = hashlib.sha256(str(project_dir).encode()).hexdigest()[:8]
+db_dir = oracle_dir / "projects" / pid
+db_dir.mkdir(parents=True, exist_ok=True)
+db_path = db_dir / "oracle.db"
+
+conn = sqlite3.connect(str(db_path))
+conn.executescript(
+    """
+    CREATE TABLE IF NOT EXISTS file_cache (
+        path TEXT PRIMARY KEY,
+        content BLOB,
+        sha256 TEXT NOT NULL,
+        disk_sha256 TEXT,
+        first_seen INTEGER NOT NULL,
+        last_read INTEGER NOT NULL,
+        read_count INTEGER DEFAULT 1
+    );
+    CREATE TABLE IF NOT EXISTS session_files (
+        session_id TEXT NOT NULL,
+        path TEXT NOT NULL,
+        served_at INTEGER NOT NULL,
+        PRIMARY KEY (session_id, path)
+    );
+    """
+)
+now = int(time.time())
+
+# Insert the target plus 999 sibling rows in file_cache.
+fake_content = b"# filler\n" * 4
+fake_sha = hashlib.sha256(fake_content).hexdigest()
+rows = [
+    (target_full, target_path.read_bytes(), target_sha, target_sha, now, now)
+]
+for i in range(999):
+    sibling_path = str(project_dir / "src" / f"sibling_{i}.py")
+    rows.append((sibling_path, fake_content, fake_sha, fake_sha, now, now))
+conn.executemany(
+    "INSERT OR REPLACE INTO file_cache "
+    "(path, content, sha256, disk_sha256, first_seen, last_read) "
+    "VALUES (?, ?, ?, ?, ?, ?)",
+    rows,
+)
+
+# Distribute 1000 session_files rows across 10 session_ids; the bench
+# session is the first one and gets the target row.
+session_rows = [("bench-session", target_full, now)]
+for sid_idx in range(10):
+    sid = f"sess-{sid_idx:02d}"
+    for j in range(100 if sid_idx > 0 else 99):
+        session_rows.append(
+            (sid, str(project_dir / "src" / f"sibling_{sid_idx * 100 + j}.py"), now)
+        )
+conn.executemany(
+    "INSERT OR REPLACE INTO session_files (session_id, path, served_at) VALUES (?, ?, ?)",
+    session_rows,
+)
+conn.commit()
+conn.close()
+
+print(f"DB={db_path}")
+print(f"TARGET_PATH={target_full}")
+PY
+
+# Build hook input JSON in a file so we feed identical input each iteration.
+INPUT_FILE="$WORKDIR/input.json"
+"$PYTHON_BIN" - "$WORKDIR" "$PROJECT_DIR" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+workdir = Path(sys.argv[1])
+project_dir = Path(sys.argv[2]).resolve()
+target = str((project_dir / "src" / "foo.py").resolve())
+payload = {
+    "session_id": "bench-session",
+    "tool_name": "Read",
+    "tool_input": {"file_path": target},
+}
+(workdir / "input.json").write_text(json.dumps(payload))
+PY
+
+ITERATIONS="${ITERATIONS:-100}"
+TIMINGS_FILE="$WORKDIR/timings.txt"
+: > "$TIMINGS_FILE"
+
+export ORACLE_DIR
+
+# Sanity check: hook exits 2 on the redundant input.
+if "$HOOK" < "$INPUT_FILE" > /dev/null 2>&1; then
+    echo "Sanity check failed: hook should have exited 2 (block) on redundant input." >&2
+    exit 1
+fi
+
+# Use Python to drive the loop — much lower per-iteration overhead than
+# spawning a Python subprocess just to read a clock between bash forks.
+"$PYTHON_BIN" - "$HOOK" "$INPUT_FILE" "$TIMINGS_FILE" "$ITERATIONS" "$ORACLE_DIR" <<'PY'
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+hook, input_file, timings_file, iterations, oracle_dir = sys.argv[1:6]
+input_bytes = Path(input_file).read_bytes()
+env = os.environ.copy()
+env["ORACLE_DIR"] = oracle_dir
+
+with Path(timings_file).open("w") as f:
+    for _ in range(int(iterations)):
+        start = time.perf_counter_ns()
+        subprocess.run(
+            [hook],
+            input=input_bytes,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            env=env,
+            check=False,
+        )
+        elapsed = time.perf_counter_ns() - start
+        f.write(f"{elapsed}\n")
+PY
+
+"$PYTHON_BIN" - "$TIMINGS_FILE" <<'PY'
+import statistics
+import sys
+from pathlib import Path
+
+timings_ns = [int(x) for x in Path(sys.argv[1]).read_text().splitlines() if x.strip()]
+timings_ms = [n / 1_000_000 for n in timings_ns]
+n = len(timings_ms)
+p50 = statistics.median(timings_ms)
+p99 = statistics.quantiles(timings_ms, n=100, method="inclusive")[98]
+print(f"iterations: {n}")
+print(f"p50: {p50:.2f} ms")
+print(f"p99: {p99:.2f} ms")
+print(f"min: {min(timings_ms):.2f} ms")
+print(f"max: {max(timings_ms):.2f} ms")
+print()
+print("budget (per issue #13 AC): p50 < 30ms, p99 < 50ms")
+status = "PASS" if (p50 < 30 and p99 < 50) else "FAIL"
+print(f"status: {status}")
+PY

--- a/src/oracle/ingest_bridge.py
+++ b/src/oracle/ingest_bridge.py
@@ -77,13 +77,11 @@ def process_ingest(
         )
         builtin_logged += 1
 
-        # For Read entries, record session_files (used by hook for binary
-        # blocking) and populate the file cache.
+        # For Read entries, record session_files only after we have
+        # successfully cached the file's content. The hook joins
+        # session_files to file_cache; a session_files row without a
+        # matching file_cache row is dead weight.
         if tool_name == "Read":
-            project.store.record_session_file(
-                session_id, str(resolved), int(time.time())
-            )
-
             if not resolved.is_file():
                 continue
 
@@ -93,6 +91,9 @@ def process_ingest(
                 continue
 
             project.file_cache.smart_read(str(resolved))
+            project.store.record_session_file(
+                session_id, str(resolved), int(time.time())
+            )
             populated += 1
 
     return IngestResult(cache_populated=populated, builtin_logged=builtin_logged)

--- a/src/oracle/ingest_bridge.py
+++ b/src/oracle/ingest_bridge.py
@@ -91,9 +91,7 @@ def process_ingest(
                 continue
 
             project.file_cache.smart_read(str(resolved))
-            project.store.record_session_file(
-                session_id, str(resolved), int(time.time())
-            )
+            project.store.record_session_file(session_id, str(resolved), int(time.time()))
             populated += 1
 
     return IngestResult(cache_populated=populated, builtin_logged=builtin_logged)

--- a/src/oracle/ingest_bridge.py
+++ b/src/oracle/ingest_bridge.py
@@ -77,8 +77,13 @@ def process_ingest(
         )
         builtin_logged += 1
 
-        # For Read entries, also populate the file cache
+        # For Read entries, record session_files (used by hook for binary
+        # blocking) and populate the file cache.
         if tool_name == "Read":
+            project.store.record_session_file(
+                session_id, str(resolved), int(time.time())
+            )
+
             if not resolved.is_file():
                 continue
 

--- a/src/oracle/server.py
+++ b/src/oracle/server.py
@@ -100,6 +100,10 @@ def oracle_read(path: str) -> str:
         return "Error: file cache not initialized"
     response, tokens_saved = project.file_cache.smart_read_with_stats(str(resolved))
     cache_hit = tokens_saved > 0
+    if project.store is not None:
+        project.store.record_session_file(
+            project.session_id, str(resolved), int(time.time())
+        )
     _log(project, "oracle_read", str(resolved), cache_hit, tokens_saved)
     return response
 

--- a/src/oracle/server.py
+++ b/src/oracle/server.py
@@ -101,9 +101,7 @@ def oracle_read(path: str) -> str:
     response, tokens_saved = project.file_cache.smart_read_with_stats(str(resolved))
     cache_hit = tokens_saved > 0
     if project.store is not None:
-        project.store.record_session_file(
-            project.session_id, str(resolved), int(time.time())
-        )
+        project.store.record_session_file(project.session_id, str(resolved), int(time.time()))
     _log(project, "oracle_read", str(resolved), cache_hit, tokens_saved)
     return response
 

--- a/src/oracle/storage/store.py
+++ b/src/oracle/storage/store.py
@@ -110,6 +110,13 @@ class OracleStore:
                 ts           INTEGER NOT NULL
             );
 
+            CREATE TABLE IF NOT EXISTS session_files (
+                session_id TEXT NOT NULL,
+                path       TEXT NOT NULL,
+                served_at  INTEGER NOT NULL,
+                PRIMARY KEY (session_id, path)
+            );
+
             CREATE INDEX IF NOT EXISTS idx_file_cache_last_read ON file_cache(last_read);
             CREATE INDEX IF NOT EXISTS idx_agent_log_session ON agent_log(session_id);
             CREATE INDEX IF NOT EXISTS idx_command_results_ran ON command_results(ran_at);
@@ -439,6 +446,42 @@ class OracleStore:
         avg_hit = sum(hit_rates) / len(hit_rates) if hit_rates else 0.0
         avg_adoption = sum(adoption_rates) / len(adoption_rates) if adoption_rates else 0.0
         return avg_hit, avg_adoption
+
+    def record_session_file(self, session_id: str, path: str, served_at: int) -> None:
+        """Insert or refresh the (session_id, path) row in session_files."""
+        self._conn.execute(
+            """
+            INSERT INTO session_files (session_id, path, served_at)
+            VALUES (?, ?, ?)
+            ON CONFLICT(session_id, path) DO UPDATE SET served_at = excluded.served_at
+            """,
+            (session_id, path, served_at),
+        )
+        self._conn.commit()
+
+    def get_session_file_served_at(self, session_id: str, path: str) -> int | None:
+        """Return served_at for (session_id, path), or None if no row exists."""
+        row = self._conn.execute(
+            "SELECT served_at FROM session_files WHERE session_id = ? AND path = ?",
+            (session_id, path),
+        ).fetchone()
+        return None if row is None else int(row["served_at"])
+
+    def get_session_file_disk_sha256(self, session_id: str, path: str) -> str | None:
+        """Return file_cache.disk_sha256 only if (session_id, path) is in session_files."""
+        row = self._conn.execute(
+            """
+            SELECT f.disk_sha256
+            FROM file_cache f
+            JOIN session_files s ON s.path = f.path
+            WHERE s.session_id = ? AND f.path = ?
+            """,
+            (session_id, path),
+        ).fetchone()
+        if row is None:
+            return None
+        disk_sha = row["disk_sha256"]
+        return None if disk_sha is None else str(disk_sha)
 
     def evict_stale_files(self, max_age_days: int = 30, now: int | None = None) -> int:
         if now is None:

--- a/tests/test_ingest_bridge.py
+++ b/tests/test_ingest_bridge.py
@@ -408,3 +408,121 @@ class DescribeBuiltinToolLogging:
         result = process_ingest(registry, oracle_dir, lambda p: None)
 
         assert result.builtin_logged == 0
+
+
+@pytest.mark.medium
+class DescribeIngestSessionFilesWrite:
+    @pytest.fixture
+    def oracle_dir(self, tmp_path: Path) -> Path:
+        d = tmp_path / ".project-oracle"
+        d.mkdir()
+        (d / "projects").mkdir()
+        (d / "ingest").mkdir()
+        return d
+
+    @pytest.fixture
+    def project_dir(self, tmp_path: Path) -> Path:
+        project = tmp_path / "test-project"
+        project.mkdir()
+        (project / ".git").mkdir()
+        (project / "pyproject.toml").write_text('[project]\nname = "test"\n')
+        (project / "hello.py").write_text("print('hello world')\n")
+        return project
+
+    def _enqueue(self, oracle_dir: Path, entry: dict) -> None:  # noqa: ANN001
+        queue_dir = oracle_dir / "ingest"
+        queue_dir.mkdir(exist_ok=True)
+        existing = list(queue_dir.glob("*.json"))
+        idx = len(existing) + 1
+        (queue_dir / f"{idx:06d}.json").write_text(json.dumps(entry))
+
+    def it_writes_session_files_on_read_event(
+        self, oracle_dir: Path, project_dir: Path
+    ) -> None:
+        from oracle.cache.file_cache import FileCache
+        from oracle.registry import ProjectRegistry
+
+        file_path = str(project_dir / "hello.py")
+        self._enqueue(
+            oracle_dir,
+            {
+                "session_id": "sess-ingest",
+                "cwd": str(project_dir),
+                "tool_name": "Read",
+                "tool_input": {"file_path": file_path},
+            },
+        )
+
+        registry = ProjectRegistry(oracle_dir)
+        project = registry.for_path(project_dir / "hello.py")
+        assert project is not None
+        assert project.store is not None
+        project.file_cache = FileCache(project.store)
+
+        def ensure_caches(p: ProjectState) -> None:
+            if p.file_cache is None and p.store is not None:
+                p.file_cache = FileCache(p.store)
+
+        process_ingest(registry, oracle_dir, ensure_caches)
+
+        served_at = project.store.get_session_file_served_at("sess-ingest", file_path)
+        assert served_at is not None
+
+    def it_does_not_write_session_files_on_bash_event(
+        self, oracle_dir: Path, project_dir: Path
+    ) -> None:
+        from oracle.registry import ProjectRegistry
+
+        self._enqueue(
+            oracle_dir,
+            {
+                "session_id": "sess-ingest",
+                "cwd": str(project_dir),
+                "tool_name": "Bash",
+                "tool_input": {"command": "ls"},
+            },
+        )
+
+        registry = ProjectRegistry(oracle_dir)
+        registry.for_path(project_dir)
+
+        process_ingest(registry, oracle_dir, lambda p: None)
+
+        # No session_files row written for Bash entries
+        project = registry.for_path(project_dir)
+        assert project is not None
+        assert project.store is not None
+        rows = project.store._conn.execute(
+            "SELECT count(*) AS c FROM session_files WHERE session_id = ?",
+            ("sess-ingest",),
+        ).fetchone()
+        assert rows["c"] == 0
+
+    def it_does_not_write_session_files_on_grep_event(
+        self, oracle_dir: Path, project_dir: Path
+    ) -> None:
+        from oracle.registry import ProjectRegistry
+
+        self._enqueue(
+            oracle_dir,
+            {
+                "session_id": "sess-ingest",
+                "cwd": str(project_dir),
+                "tool_name": "Grep",
+                "tool_input": {"pattern": "needle"},
+            },
+        )
+
+        registry = ProjectRegistry(oracle_dir)
+        registry.for_path(project_dir)
+
+        process_ingest(registry, oracle_dir, lambda p: None)
+
+        project = registry.for_path(project_dir)
+        assert project is not None
+        assert project.store is not None
+        rows = project.store._conn.execute(
+            "SELECT count(*) AS c FROM session_files WHERE session_id = ?",
+            ("sess-ingest",),
+        ).fetchone()
+        assert rows["c"] == 0

--- a/tests/test_ingest_bridge.py
+++ b/tests/test_ingest_bridge.py
@@ -436,9 +436,7 @@ class DescribeIngestSessionFilesWrite:
         idx = len(existing) + 1
         (queue_dir / f"{idx:06d}.json").write_text(json.dumps(entry))
 
-    def it_writes_session_files_on_read_event(
-        self, oracle_dir: Path, project_dir: Path
-    ) -> None:
+    def it_writes_session_files_on_read_event(self, oracle_dir: Path, project_dir: Path) -> None:
         from oracle.cache.file_cache import FileCache
         from oracle.registry import ProjectRegistry
 
@@ -560,9 +558,7 @@ class DescribeIngestSessionFilesWrite:
 
         process_ingest(registry, oracle_dir, ensure_caches)
 
-        served_at = project.store.get_session_file_served_at(
-            "sess-ingest", nonexistent
-        )
+        served_at = project.store.get_session_file_served_at("sess-ingest", nonexistent)
         assert served_at is None, (
             "session_files row leaked for a path Oracle has no cached content for"
         )

--- a/tests/test_ingest_bridge.py
+++ b/tests/test_ingest_bridge.py
@@ -526,3 +526,43 @@ class DescribeIngestSessionFilesWrite:
             ("sess-ingest",),
         ).fetchone()
         assert rows["c"] == 0
+
+    def it_does_not_write_session_files_for_nonexistent_file(
+        self, oracle_dir: Path, project_dir: Path
+    ) -> None:
+        # The hook's binary block predicate joins session_files to file_cache.
+        # Recording session_files for a path that was never cached leaks rows
+        # the hook can never use. Only record session_files when the file
+        # existed AND was cached.
+        from oracle.cache.file_cache import FileCache
+        from oracle.registry import ProjectRegistry
+
+        nonexistent = str(project_dir / "does_not_exist.py")
+        self._enqueue(
+            oracle_dir,
+            {
+                "session_id": "sess-ingest",
+                "cwd": str(project_dir),
+                "tool_name": "Read",
+                "tool_input": {"file_path": nonexistent},
+            },
+        )
+
+        registry = ProjectRegistry(oracle_dir)
+        project = registry.for_path(project_dir)
+        assert project is not None
+        assert project.store is not None
+        project.file_cache = FileCache(project.store)
+
+        def ensure_caches(p: ProjectState) -> None:
+            if p.file_cache is None and p.store is not None:
+                p.file_cache = FileCache(p.store)
+
+        process_ingest(registry, oracle_dir, ensure_caches)
+
+        served_at = project.store.get_session_file_served_at(
+            "sess-ingest", nonexistent
+        )
+        assert served_at is None, (
+            "session_files row leaked for a path Oracle has no cached content for"
+        )

--- a/tests/test_project_hash_parity.py
+++ b/tests/test_project_hash_parity.py
@@ -25,14 +25,28 @@ def python_project_hash(root: Path) -> str:
 
 
 def bash_project_hash(root: Path) -> str:
-    """Run the same shell pipeline the hook uses."""
+    """Invoke the actual project_db_path function from the hook script.
+
+    Sources the hook to load helper functions without triggering main logic
+    (the hook gates _aylo_main on BASH_SOURCE/$0). Calls project_db_path with
+    the test root and extracts the hash from the returned db path.
+    """
     result = subprocess.run(
-        ["bash", "-c", f'printf "%s" "{root}" | shasum -a 256 | head -c 8'],
+        [
+            "bash",
+            "-c",
+            f'source "{HOOK_SCRIPT}"; project_db_path "$1"',
+            "_",  # $0
+            str(root),
+        ],
         capture_output=True,
         text=True,
         check=True,
     )
-    return result.stdout
+    db_path = result.stdout.strip()
+    # project_db_path echoes "<ORACLE_DIR>/projects/<hash>/oracle.db"
+    # The 8-char hash is the parent directory name.
+    return Path(db_path).parent.name
 
 
 @pytest.mark.medium

--- a/tests/test_project_hash_parity.py
+++ b/tests/test_project_hash_parity.py
@@ -1,0 +1,72 @@
+"""Parity tests for project-ID-from-path hashing.
+
+The PreToolUse hook (`hooks/lights-on-oracle-pre.sh`) and the Python
+`ProjectRegistry` both derive a per-project SQLite database directory from
+the project root path. They MUST agree byte-for-byte, otherwise the hook
+either reads the wrong DB or no DB at all and silently fails open. These
+tests pin the algorithm to the Python implementation and exercise the bash
+hook's logic side-by-side.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import subprocess
+from pathlib import Path
+
+import pytest
+
+HOOK_SCRIPT = Path(__file__).resolve().parent.parent / "hooks" / "lights-on-oracle-pre.sh"
+
+
+def python_project_hash(root: Path) -> str:
+    """Match `ProjectRegistry.for_path` derivation in src/oracle/registry.py."""
+    return hashlib.sha256(str(root).encode()).hexdigest()[:8]
+
+
+def bash_project_hash(root: Path) -> str:
+    """Run the same shell pipeline the hook uses."""
+    result = subprocess.run(
+        ["bash", "-c", f'printf "%s" "{root}" | shasum -a 256 | head -c 8'],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout
+
+
+@pytest.mark.medium
+@pytest.mark.parametrize(
+    "rel_root",
+    [
+        "project",
+        "project/with space",
+        "deep/nested/path",
+        "trailing-slash-not-here",
+        "unicode-naïve-Ω",
+    ],
+)
+def test_python_and_bash_agree_on_project_hash(tmp_path: Path, rel_root: str) -> None:
+    root = tmp_path / rel_root
+    root.mkdir(parents=True)
+
+    py_hash = python_project_hash(root)
+    sh_hash = bash_project_hash(root)
+
+    assert py_hash == sh_hash, (
+        f"Project-hash drift between Python and bash for root={root!r}:\n"
+        f"  python -> {py_hash}\n"
+        f"  bash   -> {sh_hash}\n"
+        "If these disagree, the hook will read the wrong DB."
+    )
+
+
+@pytest.mark.small
+def test_hook_script_uses_documented_hash_pipeline() -> None:
+    """Pin the bash pipeline so any future edit forces this test to be revisited."""
+    text = HOOK_SCRIPT.read_text()
+    assert "shasum -a 256 | head -c 8" in text, (
+        "Hook no longer derives project ID via `shasum -a 256 | head -c 8`. "
+        "If the algorithm changed, update ProjectRegistry to match and revise "
+        "the parity test before merging."
+    )

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -777,6 +777,83 @@ class DescribeOracleForgetFileCacheNone:
         assert "file cache not initialized" in result.lower()
 
 
+class DescribeOracleReadSessionFilesWrite:
+    """Verify oracle_read writes to session_files on every successful serve."""
+
+    @pytest.fixture
+    def oracle_dir(self, tmp_path: Path) -> Path:
+        d = tmp_path / ".oracle"
+        d.mkdir()
+        (d / "projects").mkdir()
+        return d
+
+    @pytest.fixture
+    def project_dir(self, tmp_path: Path) -> Path:
+        project = tmp_path / "proj"
+        project.mkdir()
+        (project / ".git").mkdir()
+        (project / "pyproject.toml").write_text('[project]\nname = "test"\n')
+        (project / "hello.py").write_text("print('hello world')\n")
+        return project
+
+    def it_records_session_file_on_first_read(
+        self, oracle_dir: Path, project_dir: Path, mocker: MockerFixture
+    ) -> None:
+        from oracle.registry import ProjectRegistry
+        from oracle.server import oracle_read
+
+        registry = ProjectRegistry(oracle_dir)
+        mocker.patch("oracle.server._registry", registry)
+
+        file_path = str(project_dir / "hello.py")
+        oracle_read(file_path)
+
+        project = registry.for_path(project_dir / "hello.py")
+        assert project is not None
+        assert project.store is not None
+        served_at = project.store.get_session_file_served_at(project.session_id, file_path)
+        assert served_at is not None
+
+    def it_records_session_file_on_repeat_read(
+        self, oracle_dir: Path, project_dir: Path, mocker: MockerFixture
+    ) -> None:
+        from oracle.registry import ProjectRegistry
+        from oracle.server import oracle_read
+
+        registry = ProjectRegistry(oracle_dir)
+        mocker.patch("oracle.server._registry", registry)
+
+        file_path = str(project_dir / "hello.py")
+        oracle_read(file_path)
+        oracle_read(file_path)
+
+        project = registry.for_path(project_dir / "hello.py")
+        assert project is not None
+        assert project.store is not None
+        served_at = project.store.get_session_file_served_at(project.session_id, file_path)
+        assert served_at is not None
+
+    def it_does_not_record_session_file_when_path_outside_root(
+        self, oracle_dir: Path, project_dir: Path, mocker: MockerFixture
+    ) -> None:
+        from oracle.registry import ProjectRegistry
+        from oracle.server import oracle_read
+
+        registry = ProjectRegistry(oracle_dir)
+        mocker.patch("oracle.server._registry", registry)
+
+        # Establish project context first
+        oracle_read(str(project_dir / "hello.py"))
+        # Then try a path outside project root
+        oracle_read("/etc/passwd")
+
+        project = registry.for_path(project_dir / "hello.py")
+        assert project is not None
+        assert project.store is not None
+        served_at = project.store.get_session_file_served_at(project.session_id, "/etc/passwd")
+        assert served_at is None
+
+
 class DescribeMainEntryPoint:
     """Test the main() entry point."""
 

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -48,7 +48,13 @@ class DescribeOracleStoreInit:
             cursor = conn.execute("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name")
             tables = sorted(row[0] for row in cursor.fetchall() if not row[0].startswith("sqlite_"))
             conn.close()
-            assert tables == ["agent_log", "command_results", "file_cache", "git_state"]
+            assert tables == [
+                "agent_log",
+                "command_results",
+                "file_cache",
+                "git_state",
+                "session_files",
+            ]
         finally:
             store2.close()
 
@@ -60,9 +66,55 @@ class DescribeOracleStoreInit:
             cursor = conn.execute("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name")
             tables = sorted(row[0] for row in cursor.fetchall() if not row[0].startswith("sqlite_"))
             conn.close()
-            assert tables == ["agent_log", "command_results", "file_cache", "git_state"]
+            assert tables == [
+                "agent_log",
+                "command_results",
+                "file_cache",
+                "git_state",
+                "session_files",
+            ]
         finally:
             store.close()
+
+
+@pytest.mark.medium
+class DescribeSessionFilesOperations:
+    def it_records_a_session_file_serve(self, store: OracleStore) -> None:
+        store.record_session_file("sess-1", "src/foo.py", 1000)
+        served_at = store.get_session_file_served_at("sess-1", "src/foo.py")
+        assert served_at == 1000
+
+    def it_returns_none_when_session_file_missing(self, store: OracleStore) -> None:
+        assert store.get_session_file_served_at("sess-x", "src/missing.py") is None
+
+    def it_replaces_served_at_on_repeat_record(self, store: OracleStore) -> None:
+        store.record_session_file("sess-1", "src/foo.py", 1000)
+        store.record_session_file("sess-1", "src/foo.py", 2000)
+        assert store.get_session_file_served_at("sess-1", "src/foo.py") == 2000
+
+    def it_isolates_rows_per_session(self, store: OracleStore) -> None:
+        store.record_session_file("sess-A", "src/foo.py", 1000)
+        store.record_session_file("sess-B", "src/foo.py", 2000)
+        assert store.get_session_file_served_at("sess-A", "src/foo.py") == 1000
+        assert store.get_session_file_served_at("sess-B", "src/foo.py") == 2000
+
+    def it_returns_disk_sha_only_when_session_file_present(self, store: OracleStore) -> None:
+        store.upsert_file_cache("src/foo.py", b"data", "abc", "disk-hash-1", 1000)
+        # No session_files row yet
+        assert store.get_session_file_disk_sha256("sess-1", "src/foo.py") is None
+        store.record_session_file("sess-1", "src/foo.py", 1500)
+        assert store.get_session_file_disk_sha256("sess-1", "src/foo.py") == "disk-hash-1"
+
+    def it_returns_none_when_file_cache_missing_even_if_session_present(
+        self, store: OracleStore
+    ) -> None:
+        store.record_session_file("sess-1", "src/orphan.py", 1500)
+        assert store.get_session_file_disk_sha256("sess-1", "src/orphan.py") is None
+
+    def it_returns_none_for_other_sessions(self, store: OracleStore) -> None:
+        store.upsert_file_cache("src/foo.py", b"data", "abc", "disk-hash-1", 1000)
+        store.record_session_file("sess-A", "src/foo.py", 1500)
+        assert store.get_session_file_disk_sha256("sess-B", "src/foo.py") is None
 
 
 @pytest.mark.medium


### PR DESCRIPTION
## Summary

Rewrites the AYLO PreToolUse hook from advisory (always exit 0, emit \`additionalContext\`) to binary blocking on redundant \`Read\` calls. Live evidence motivated this: the prior advisory hook fired four times in a single conversation, escalating from \"STOP\" through \"you are consistently ignoring oracle_read\", and the agent (Claude Opus 4.7) used the built-in \`Read\` every time. Per Anthropic's hook docs, hooks are reliable when binary (exit 2 → blocked, stderr → model feedback) and brittle when advisory.

The new hook blocks \`Read\` only when **all** of:
1. \`(session_id, path)\` is in the new \`session_files\` table (file served this session via \`oracle_read\` OR captured by PostToolUse ingest)
2. \`file_cache.disk_sha256\` matches the on-disk SHA-256 (file unchanged since last read)
3. The lookup completes within the timeout
4. The path resolves to a tracked project

In every other case (first read, changed file, partial read, oracle unreachable, hook timeout), the hook exits 0 silently. The escalation counter is removed. Bash and Grep paths remain advisory in this PR.

Closes #13.

## Changes

**New:**
- \`session_files (session_id, path, served_at)\` table with composite PK (additive migration in \`store.py\`)
- \`features/hooks.feature\` — 15 BDD scenarios tagged \`@ISSUE-13\`, mapped 1:1 to AC
- \`features/steps/hook_steps.py\` — exercises the real hook binary against per-scenario SQLite fixtures
- \`scripts/bench_hook.sh\` — 100-iteration p50/p99 benchmark

**Modified:**
- \`hooks/lights-on-oracle-pre.sh\` — binary block on Read; escalation counter removed; advisory behavior preserved on Bash/Grep
- \`src/oracle/server.py\` — \`oracle_read\` writes to \`session_files\` on every serve
- \`src/oracle/ingest_bridge.py\` — writes to \`session_files\` only after successful cache population (prevents leak on missing files)
- \`README.md\` — \"How It Works\" table and architecture footer reflect binary blocking

## Gauntlet

Adversarial review found one CRITICAL and several HIGH/MEDIUM. Addressed in commits 2de375d, cf5966d, ea9497c:
- **C1 (perf):** Hot path consolidated from 6 jq invocations to 1; sqlite3 + shasum now run in parallel. Bench improved p50 88→61ms / p99 109→67ms. Still over the 30/50ms AC budget — bash interpreter startup + sqlite3 cold open are the residual cost. Tracked as follow-up #16.
- **H4:** \`ingest_bridge.py\` no longer leaks \`session_files\` rows for nonexistent files. New regression test.
- **M3:** Partial-Read BDD scenario now actually triangulates the partial-read short-circuit (was passing for the wrong reason — empty file_cache fall-through).

Quality suite (verified post-fix):
- \`uv run pytest\`: 467 passed
- \`uv run mypy src/\`: clean (25 files, no errors)
- \`uv run ruff check\`: clean
- \`uv run behave features/hooks.feature\`: 15 scenarios, 105 steps pass

## Performance Note

The hook still exceeds the 30/50ms AC budget at p50 ~61ms / p99 ~67ms. The current implementation (bash + sqlite3 CLI) cannot clear the budget on macOS due to bash startup + sqlite3 cold-open costs. The behavior is correct and ships an improvement over the previous advisory hook (which had similar overhead with no benefit). A compiled-helper rewrite is tracked as #16 and is the realistic path to budget compliance.

## Out of Scope (per #13)

- Grep blocking — separate follow-up planned
- Bash command interception — stays advisory
- Cross-session redundant-read detection — same-session only
- \`session_files\` retention/eviction policy

## Test plan

- [x] 15 BDD scenarios cover redundant-blocked, cross-session-allowed, ingest-race-allowed, partial-read-allowed, full-after-partial-blocked, symlinks, oracle-unreachable-allowed, hook-timeout-allowed, escalation-counter-removed, and Bash/Grep advisory unchanged
- [x] Python unit tests cover both \`session_files\` writers (oracle_read serve path + ingest worker)
- [x] Pre-existing \`PYTHONPATH\` issue noted by the dev agent is a red herring for this branch — \`behave\` runs cleanly

🤖 Generated with [Claude Code](https://claude.ai/claude-code)